### PR TITLE
Implement department display with color-coded borders

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -76,6 +76,7 @@ ul.languages {
     padding: 15px;
     box-shadow: 0 2px 5px rgba(0,0,0,0.1);
     transition: transform 0.3s ease;
+    border-right: 8px solid transparent;
 }
 
 .card:hover {
@@ -146,6 +147,11 @@ ul.languages {
 
 .certified {
     border: 1px solid green;
+}
+
+.department-label {
+    font-weight: bold;
+    float: right;
 }
 
 /* Anzeige des aktuellen Filters */


### PR DESCRIPTION
## Summary
- show departments in data by extending JSON load
- color-code person cards according to department
- indicate department in modal and on card
- style cards and department label

## Testing
- `node -e "require('./script.js');"` *(fails: document is not defined)*

------
https://chatgpt.com/codex/tasks/task_e_688668807cc4832780e865d68bbe54e3