### PR TITLE
Add SIM card details to device agreement

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Das Projekt stellt ein webbasiertes Adressbuch der „IFAK Familie“ bereit. HT
 | `list.php`                | Erstellt eine allgemeine Mitarbeitendenliste als PDF mit FPDF.                                                                         |
 | `fpdf.php` und `font/`    | Eingebundene PDF-Bibliothek und Schriftdateien.                                                                                        |
 | `README.md`, `roadmap.md` | Sehr knappes Projektintro und offene Punkte.                                                                                           |
-| `vz.php`                  | Über die vz.php können Ausgabezettel für die Passwörter der Mitarbeitenden und eine Vereinbarung zur überlassung von Arbeitsmitteln erstellt werden.                                                                         |
+| `vz.php`                  | Über die vz.php können Ausgabezettel für die Passwörter der Mitarbeitenden und eine Vereinbarung zur überlassung von Arbeitsmitteln erstellt werden. Optional lassen sich SIM-Karten mit Rufnummer und PIN erfassen und ins Adressbuch exportieren. |
 | `.gitignore`              | Schließt Datenbankdateien und lokale Artefakte aus dem Repository aus.                                                                 |
 
 

--- a/vereinbarung_pdf.php
+++ b/vereinbarung_pdf.php
@@ -134,6 +134,17 @@ for ($i = 0; $i <= 4; $i++) {
     }
 }
 
+if (!empty($_POST['sim_phone'])) {
+    $pdf->Ln(5);
+    $pdf->SetFont('DejaVu','B',10);
+    $pdf->Cell(0,6,'SIM-Karte:',0,1);
+    $pdf->SetFont('DejaVu','',10);
+    $pdf->Cell(46,6,'Rufnummer:',0,0);
+    $pdf->Cell(0,6,$_POST['sim_phone'],0,1);
+    $pdf->Cell(46,6,'PIN:',0,0);
+    $pdf->Cell(0,6,$_POST['sim_pin'] ?? '',0,1);
+}
+
 $pdf->Ln(20);
 $pdf->Cell(100,4,'Bochum, den '.date("d.m.Y"),0,0);
 $pdf->Cell(60,4,'',0,1);
@@ -147,6 +158,26 @@ $pdf->AddPage();
 $pdf->SetLeftMargin(10);
 
 $pdf->PrintChapter('vereinbarung.txt');
+
+$simExport = !empty($_POST['sim_export']);
+if ($simExport && !empty($_POST['sim_phone'])) {
+    $entry = [
+        'name' => $_POST['Name'] ?? '',
+        'phone' => $_POST['sim_phone'],
+        'pin' => $_POST['sim_pin'] ?? ''
+    ];
+    $jsonFile = 'simcards.json';
+    $jsonData = [];
+    if (file_exists($jsonFile)) {
+        $content = file_get_contents($jsonFile);
+        $jsonData = json_decode($content, true);
+        if (!is_array($jsonData)) {
+            $jsonData = [];
+        }
+    }
+    $jsonData[] = $entry;
+    file_put_contents($jsonFile, json_encode($jsonData, JSON_UNESCAPED_UNICODE | JSON_PRETTY_PRINT));
+}
 
 $name = $_POST['Name'] ?? '';
 $dateiname = date("Ymd")."-Vereinbarung_Arbeitsmittel-".preg_replace('/[^a-zA-Z0-9]/','_', strtolower(umlauteumwandeln($name))).'.pdf';

--- a/vz.php
+++ b/vz.php
@@ -140,22 +140,48 @@ if ($EmployeeID !== '') {
 					<label for="kennzeichnung">Kennzeichnung:</label>
 					<input type="text" name="kennzeichnung[]" placeholder="Kennzeichnung">
 	    		</div>
-		    </div>
-		    </div>
+                    </div>
+                    </div>
+                    <div class="form-block">
+                        <div class="form-row">
+                                <input type="checkbox" id="sim_check" name="sim_check" onclick="toggleSimFields()">
+                                <label for="sim_check">mit SIM-Karte</label>
+                        </div>
+                        <div id="sim_fields" style="display:none;">
+                                <div class="form-row">
+                                        <label for="sim_phone">Telefonnummer:</label>
+                                        <input type="text" id="sim_phone" name="sim_phone">
+                                </div>
+                                <div class="form-row">
+                                        <label for="sim_pin">PIN:</label>
+                                        <input type="text" id="sim_pin" name="sim_pin">
+                                </div>
+                                <div class="form-row">
+                                        <input type="checkbox" id="sim_export" name="sim_export" value="1">
+                                        <label for="sim_export">In Adressbuch übernehmen</label>
+                                </div>
+                        </div>
+                    </div>
 <div style="display: flex; justify-content: space-between; gap: 1rem; margin-top: 1rem;">
     <button type="button" onclick="addArbeitsmittel()">+ weiteres Arbeitsmittel</button>
     <button type="submit">Vereinbarung drucken</button>
 </div>
-		</fieldset>
-	</form>
+                </fieldset>
+        </form>
 </div>
 
 <script>
-	function addArbeitsmittel() {
+        function addArbeitsmittel() {
   const tmpl = document.querySelector('.arbeitsmittel-gruppe');
   const clone = tmpl.cloneNode(true);
   // Leere Felder
   clone.querySelectorAll('input').forEach(i => i.value = '');
   document.getElementById('arbeitsmittel-container').appendChild(clone);
+}
+
+function toggleSimFields() {
+  const check = document.getElementById('sim_check');
+  const fields = document.getElementById('sim_fields');
+  fields.style.display = check.checked ? 'block' : 'none';
 }
 </script>


### PR DESCRIPTION
## Summary
- allow capturing SIM card number and PIN in device agreement form
- include SIM info in generated agreement PDF and append to simcards.json when requested
- document optional SIM card export feature

## Testing
- `php -l vz.php`
- `php -l vereinbarung_pdf.php`


------
https://chatgpt.com/codex/tasks/task_e_688e1e7cba348327856fc69e81db022c