### PR TITLE
Add timestamp to SIM card exports

### DIFF
--- a/simcards.json
+++ b/simcards.json
@@ -2,11 +2,13 @@
     {
         "name": " Nuener Mitarbeiter",
         "phone": "0190 332 332",
-        "pin": "9856"
+        "pin": "9856",
+        "timestamp": "2025-08-02T15:53:52+00:00"
     },
     {
         "name": "Rama Al Sayasneh",
         "phone": "0234 112",
-        "pin": "1237"
+        "pin": "1237",
+        "timestamp": "2025-08-02T15:53:52+00:00"
     }
 ]

--- a/vereinbarung_pdf.php
+++ b/vereinbarung_pdf.php
@@ -164,7 +164,8 @@ if ($simExport && !empty($_POST['sim_phone'])) {
     $entry = [
         'name' => $_POST['Name'] ?? '',
         'phone' => $_POST['sim_phone'],
-        'pin' => $_POST['sim_pin'] ?? ''
+        'pin' => $_POST['sim_pin'] ?? '',
+        'timestamp' => date('c')
     ];
     $jsonFile = 'simcards.json';
     $jsonData = [];


### PR DESCRIPTION
## Summary
- Add ISO 8601 timestamp to SIM card export entries
- Include timestamp in existing simcards.json sample data

## Testing
- `php -l vereinbarung_pdf.php`
- `jq . simcards.json`


------
https://chatgpt.com/codex/tasks/task_e_688e342eceb483278f807ee51baed592