### PR TITLE
Add department cards with filtering and modal details

### DIFF
--- a/index.php
+++ b/index.php
@@ -34,6 +34,7 @@
                     <option value="person">Personen</option>
                     <option value="facility">Einrichtungen</option>
                     <option value="location">Standorte</option>
+                    <option value="department">Fachbereiche</option>
                 </select>
             </div>
         </div>

--- a/script.js
+++ b/script.js
@@ -70,6 +70,9 @@ function renderData(filterType = 'all', languageFilter = null, languageLevelFilt
     if (filterType === 'all' || filterType === 'location') {
         filteredData = filteredData.concat(data.locations);
     }
+    if (filterType === 'all' || filterType === 'department') {
+        filteredData = filteredData.concat(data.departments);
+    }
 
     console.log("Filtered data:", filteredData);
 
@@ -117,6 +120,13 @@ function filterAndRenderData(searchTerm, filterType, languageFilter = null, lang
             const address = location.address || '';
             return name.toLowerCase().includes(searchTerm) ||
                 address.toLowerCase().includes(searchTerm);
+        }));
+    }
+
+    if (filterType === 'all' || filterType === 'department') {
+        filteredData = filteredData.concat(data.departments.filter(department => {
+            const name = department.name || '';
+            return name.toLowerCase().includes(searchTerm);
         }));
     }
 
@@ -206,8 +216,13 @@ function renderCards(filteredData, languageFilter = null, languageLevelFilter = 
             details += `Standort: ${getLocationName(item.location)}`;
             card = createCard('facility', item.name, details, item, item.department);
 //             card = createCard('facility', item.name, , item);
-        } else {
+        } else if (item.hasOwnProperty('address')) {
             card = createCard('location', item.name, item.address, item);
+        } else {
+            const facilities = getFacilitiesInDepartment(item.id);
+            const persons = getPersonsInDepartment(item.id);
+            const details = `${facilities.length} Einrichtungen / ${persons.length} Personen`;
+            card = createCard('department', item.name, details, item, item.id);
         }
         mosaic.appendChild(card);
     });
@@ -224,6 +239,9 @@ function createCard(type, title, details, fullData, departmentId = null) {
     `;
     if ((type === 'person' || type === 'facility') && departmentId) {
         const color = getDepartmentColor(departmentId);
+        card.style.borderRight = `8px solid ${color}`;
+    } else if (type === 'department') {
+        const color = fullData.color || getDepartmentColor(fullData.id);
         card.style.borderRight = `8px solid ${color}`;
     }
     card.addEventListener('click', () => showDetails(type, fullData));
@@ -426,16 +444,36 @@ function showDetails(type, itemData) {
 			        detailsHtml += `<p>Adresse: <a href="https://www.google.com/maps/search/?api=1&query=${encodeURIComponent(itemData.address)}" target="_blank">${itemData.address}</a></p>`;
 			    }
 			
-			    const facilitiesInLocation = getFacilitiesInLocation(itemData.id);
+                        const facilitiesInLocation = getFacilitiesInLocation(itemData.id);
 			
 			    if (facilitiesInLocation && facilitiesInLocation.length > 0) {
 			        detailsHtml += `<h3>Einrichtungen/Projekte:</h3>
 			        <ul>${facilitiesInLocation.map(f => `<li><a href="#" data-type="facility" data-id="${f.id}">${f.name}</a></li>`).join('')}</ul>`;
-			    } else {
-			        detailsHtml += `<p>Keine Einrichtungen an diesem Standort.</p>`;
-			    }
-			
-			    break;
+                            } else {
+                                detailsHtml += `<p>Keine Einrichtungen an diesem Standort.</p>`;
+                            }
+
+                            break;
+        case 'department':
+
+                            detailsHtml = `
+                                <h2>Fachbereich</h2>
+                                <h1>${itemData.name}</h1>
+                            `;
+
+                            const facilitiesInDepartment = getFacilitiesInDepartment(itemData.id);
+                            if (facilitiesInDepartment && facilitiesInDepartment.length > 0) {
+                                detailsHtml += `<h3>Einrichtungen/Projekte:</h3>`;
+                                detailsHtml += `<ul>${facilitiesInDepartment.map(f => `<li><a href="#" data-type="facility" data-id="${f.id}">${f.name}</a></li>`).join('')}</ul>`;
+                            }
+
+                            const personsInDepartment = getPersonsInDepartment(itemData.id);
+                            if (personsInDepartment && personsInDepartment.length > 0) {
+                                detailsHtml += `<h3>Mitarbeitende:</h3>`;
+                                detailsHtml += `<ul>${personsInDepartment.map(p => `<li><a href="#" data-type="person" data-id="${p.id}">${p.name}</a></li>`).join('')}</ul>`;
+                            }
+
+                            break;
     }
 
     content.innerHTML = detailsHtml;
@@ -454,7 +492,7 @@ function showDetails(type, itemData) {
 
 
     // Hintergrundfarbe basierend auf dem Typ einstellen
-    content.classList.remove('person-modal', 'facility-modal', 'location-modal');
+    content.classList.remove('person-modal', 'facility-modal', 'location-modal', 'department-modal');
     if (type === 'person') {
         content.classList.add('person-modal');
         if (departmentIds.length > 0) {
@@ -473,6 +511,13 @@ function showDetails(type, itemData) {
         }
     } else if (type === 'location') {
         content.classList.add('location-modal');
+    } else if (type === 'department') {
+        content.classList.add('department-modal');
+        if (itemData.color) {
+            content.style.borderRight = `8px solid ${itemData.color}`;
+        } else {
+            content.style.borderRight = '';
+        }
     }
 
     
@@ -496,6 +541,9 @@ function showDetails(type, itemData) {
                         break;
                     case 'location':
                         newItemData = data.locations.find(l => l.id === clickedId);
+                        break;
+                    case 'department':
+                        newItemData = data.departments.find(d => d.id === clickedId);
                         break;
                 }
                 if (newItemData) {
@@ -557,6 +605,17 @@ function getPersonsInFacility(facilityId) {
             return null;
         }
     }).filter(entry => entry !== null);
+}
+
+function getFacilitiesInDepartment(departmentId) {
+    return data.facilities.filter(f => f.department === departmentId);
+}
+
+function getPersonsInDepartment(departmentId) {
+    return data.persons.filter(person => {
+        const departments = person.department ? [person.department] : getPersonDepartments(person);
+        return departments.includes(departmentId);
+    });
 }
 
 function getFacilitiesInLocation(locationId) {

--- a/styles.css
+++ b/styles.css
@@ -188,6 +188,10 @@ ul.languages {
     background-color: #B2D8B2; /* Light Green */
 }
 
+.department-card {
+    background-color: #E6C9F5; /* Pastelllila */
+}
+
 /* Hintergrundfarben für das Modal basierend auf dem Typ */
 .modal-content.person-modal {
     background-color: #add8e6; /* Pastellblau für Personen */
@@ -199,6 +203,10 @@ ul.languages {
 
 .modal-content.location-modal {
     background-color: #B2D8B2; /* Light Green für Standorte */
+}
+
+.modal-content.department-modal {
+    background-color: #E6C9F5; /* Pastelllila für Fachbereiche */
 }
 
 /* Optionale Stile für den Modalinhalt, um die Lesbarkeit sicherzustellen */


### PR DESCRIPTION
## Summary
- Support departments alongside persons, facilities, and locations
- Render color-coded department cards and modal views with linked entities
- Add styles and filter option for department cards

## Testing
- `node --check script.js`
- `php -l index.php`


------
https://chatgpt.com/codex/tasks/task_e_68b2c574836c83279f1a6345a53ebf86