### PR TITLE
Load default departments CSV in visualization

### DIFF
--- a/visualize.html
+++ b/visualize.html
@@ -67,4 +67,19 @@ document.getElementById('file').addEventListener('change', async (e)=>{
   render(data, document.getElementById('q').value);
 });
 document.getElementById('q').addEventListener('input', (e)=>render(data, e.target.value));
+
+// automatisch vorhandene departments.csv laden
+async function loadDefaultCSV(){
+  try{
+    const resp = await fetch('departments.csv');
+    if(resp.ok){
+      const text = await resp.text();
+      data = parseCSV(text);
+      render(data, document.getElementById('q').value);
+    }
+  }catch(err){
+    console.warn('departments.csv konnte nicht geladen werden', err);
+  }
+}
+loadDefaultCSV();
 </script>


### PR DESCRIPTION
## Summary
- Automatically fetch `departments.csv` on page load so data is shown immediately

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b2d1016b3883279d472368eb285287