### PR TITLE
Sort departments by ID in SharePoint export

### DIFF
--- a/export_sharepoint_csv.py
+++ b/export_sharepoint_csv.py
@@ -20,14 +20,16 @@ from typing import Iterable, List
 
 
 def fetch_departments(cursor: sqlite3.Cursor) -> Iterable[sqlite3.Row]:
-    """Return all departments.
+    """Return all departments ordered by their IDs.
 
     The returned rows expose the columns ``DepartmentID``, ``Short`` and
-    ``Department`` (voller Name) wie in ``ifak.db.sql`` definiert.
+    ``Department`` (voller Name) wie in ``ifak.db.sql`` definiert. Ordering by
+    ``DepartmentID`` ensures the generated CSV follows the database's natural
+    department sequence.
     """
 
     cursor.execute(
-        "SELECT DepartmentID, Short, Department FROM Departments ORDER BY Short"
+        "SELECT DepartmentID, Short, Department FROM Departments ORDER BY DepartmentID"
     )
     return cursor.fetchall()
 


### PR DESCRIPTION
## Summary
- ensure SharePoint CSV export orders departments by their ID for consistent output

## Testing
- `python -m py_compile export_sharepoint_csv.py`
- `pytest >/tmp/pytest.log && tail -n 20 /tmp/pytest.log`


------
https://chatgpt.com/codex/tasks/task_e_68b31021328c8327b06a2f848166a375