### PR TITLE
Add language filter badges to mosaic cards

### DIFF
--- a/script.js
+++ b/script.js
@@ -178,6 +178,19 @@ function renderCards(filteredData, languageFilter = null, languageLevelFilter = 
             if (phones.length > 0) {
                 details += phones.join(' / ') + '<br>';
             }
+            if (item.languages && item.languages.length > 0) {
+                const maxBadges = 3;
+                let badgeHtml = '<div class="language-badges">';
+                const badges = item.languages.slice(0, maxBadges).map(lang =>
+                    `<a href="#" data-filter="language" data-value="${lang.name}" class="language-badge">${lang.name.slice(0,2).toUpperCase()}</a>`
+                ).join('');
+                badgeHtml += badges;
+                if (item.languages.length > maxBadges) {
+                    badgeHtml += `<span class="language-badge">+${item.languages.length - maxBadges}</span>`;
+                }
+                badgeHtml += '</div>';
+                details += badgeHtml;
+            }
 
             const departmentIds = item.department ? [item.department] : getPersonDepartments(item);
 
@@ -656,6 +669,16 @@ document.querySelector('.search-bar').addEventListener('input', (e) => {
 document.getElementById('filterType').addEventListener('change', (e) => {
     const searchTerm = document.querySelector('.search-bar').value.toLowerCase();
     filterAndRenderData(searchTerm, e.target.value);
+});
+
+document.getElementById('dataMosaic').addEventListener('click', (e) => {
+    const target = e.target.closest('[data-filter="language"]');
+    if (target) {
+        e.preventDefault();
+        const clickedLanguage = target.dataset.value || target.textContent;
+        renderData('person', clickedLanguage);
+        updateFilterDisplay(clickedLanguage, null);
+    }
 });
 
 document.querySelector('.close').addEventListener('click', () => {

--- a/styles.css
+++ b/styles.css
@@ -158,6 +158,12 @@ ul.languages {
     font-size: 12px;
     background-color: #e0e0e0;
 }
+.language-badge {
+    display:inline-block;
+    margin:2px; padding:2px 4px;
+    font-size:10px; border-radius:3px;
+    background:#e0e0e0; cursor:pointer;
+}
 
 .certified {
     border: 1px solid green;


### PR DESCRIPTION
## Summary
- Display up to three language badges on person cards with overflow count
- Add mosaic click handler to filter by selected language
- Provide basic styling for language badges

## Testing
- `node --check script.js`
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b3138ed0e883278409197e055b9546