### PR TITLE
Add footer language filter

### DIFF
--- a/index.php
+++ b/index.php
@@ -76,14 +76,15 @@
 	        <div class="right">
 	            Export: <a href="<?php echo $_SERVER['PHP_SELF']; ?>?main=phonelist">Telefonliste</a> / <a href="<?php echo $_SERVER['PHP_SELF']; ?>?main=phonelist&amp;show=all">Telefonliste (lang)</a> / <a href="<?php echo $_SERVER['PHP_SELF']; ?>?main=list">Mitarbeitendenliste</a> : <a href="<?php echo $_SERVER['PHP_SELF']; ?>?main=vz">VZ</a>
 	        </div>
-	    </div>
+            </div>
+        <div class="language-filter" id="languageFooter"></div>
         <div class="logo-container">
-	        <a target="_blank" href="https://ifak-bochum.de"><img src="img/IFAK-Logo.svg" alt="IFAK e.V." class="company-logo"></a>
-	        <a target="_blank" href="https://ifak-bochum.de/fachbereich-fruehkindliche-bildung/"><img src="img/IFAK-Kindergarten-Logo.png" alt="IFAK Kindergarten e.V." class="company-logo"></a>
-	        <a target="_blank" href="https://frauenzentrum-dortmund.de"><img src="img/Frauenzentrum-Logo.png" alt="Frauenzentrum Dortmund" class="company-logo"></a>
-	        <a target="_blank" href="https://institut-dinx.de"><img src="img/DINX-Logo.png" alt="Institut DINX" class="company-logo"></a>
-	        <a target="_blank" href="https://intercare-pflege.de"><img src="img/InterCare-Logo.png" alt="Intercare GmbH" class="company-logo"></a>
-		</div>
+                <a target="_blank" href="https://ifak-bochum.de"><img src="img/IFAK-Logo.svg" alt="IFAK e.V." class="company-logo"></a>
+                <a target="_blank" href="https://ifak-bochum.de/fachbereich-fruehkindliche-bildung/"><img src="img/IFAK-Kindergarten-Logo.png" alt="IFAK Kindergarten e.V." class="company-logo"></a>
+                <a target="_blank" href="https://frauenzentrum-dortmund.de"><img src="img/Frauenzentrum-Logo.png" alt="Frauenzentrum Dortmund" class="company-logo"></a>
+                <a target="_blank" href="https://institut-dinx.de"><img src="img/DINX-Logo.png" alt="Institut DINX" class="company-logo"></a>
+                <a target="_blank" href="https://intercare-pflege.de"><img src="img/InterCare-Logo.png" alt="Intercare GmbH" class="company-logo"></a>
+                </div>
     </footer>
     <script src="script.js?v=14"></script>
     <script>

--- a/script.js
+++ b/script.js
@@ -22,6 +22,7 @@ async function loadData() {
             data.departments = [];
         }
         console.log("Data loaded successfully:", data);
+        populateLanguageFooter();
         renderData();
     } catch (error) {
         console.error('Error loading data:', error);
@@ -50,6 +51,21 @@ function updateHeaderWords() {
         word1Element.classList.remove('fade-out');
         word2Element.classList.remove('fade-out');
     }, 2000); // Wartezeit entspricht der CSS-Transition-Dauer
+}
+
+function populateLanguageFooter() {
+    const footer = document.getElementById('languageFooter');
+    if (!footer) return;
+    const languages = new Set();
+    data.persons.forEach(person => {
+        if (person.languages) {
+            person.languages.forEach(lang => languages.add(lang.name));
+        }
+    });
+    const links = Array.from(languages)
+        .sort()
+        .map(lang => `<a href="#" data-filter="language" data-value="${lang}">${lang}</a>`);
+    footer.innerHTML = links.join(' | ');
 }
 
 function renderData(filterType = 'all', languageFilter = null, languageLevelFilter = null) {
@@ -672,6 +688,16 @@ document.getElementById('filterType').addEventListener('change', (e) => {
 });
 
 document.getElementById('dataMosaic').addEventListener('click', (e) => {
+    const target = e.target.closest('[data-filter="language"]');
+    if (target) {
+        e.preventDefault();
+        const clickedLanguage = target.dataset.value || target.textContent;
+        renderData('person', clickedLanguage);
+        updateFilterDisplay(clickedLanguage, null);
+    }
+});
+
+document.getElementById('languageFooter').addEventListener('click', (e) => {
     const target = e.target.closest('[data-filter="language"]');
     if (target) {
         e.preventDefault();

--- a/styles.css
+++ b/styles.css
@@ -279,6 +279,13 @@ footer .exports {
     list-style: none;
     padding: 0;
 }
+footer .language-filter {
+    text-align: center;
+}
+footer .language-filter a {
+    color: #777;
+    margin: 0 5px;
+}
 .logo-container {
     display: flex;
     justify-content: space-around; /* Logos gleichmäßig über die Breite verteilen */


### PR DESCRIPTION
## Summary
- add placeholder in footer for language filter links
- populate footer with available languages and react to clicks
- style language footer to stay unobtrusive

## Testing
- `node --check script.js`
- `php -l index.php`


------
https://chatgpt.com/codex/tasks/task_e_68b314a0aba48327967627c4f5793608