### PR TITLE
Passe Spalten im Department-Modal an

### DIFF
--- a/script.js
+++ b/script.js
@@ -502,13 +502,13 @@ function showDetails(type, itemData) {
                                 detailsHtml += `<div class="department-columns">`;
 
                                 if (facilitiesInDepartment && facilitiesInDepartment.length > 0) {
-                                    detailsHtml += `<div class="department-column"><h3>Einrichtungen</h3><ul>${facilitiesInDepartment
+                                    detailsHtml += `<div class="department-column facilities-column"><h3>Einrichtungen</h3><ul>${facilitiesInDepartment
                                         .map(f => `<li><a href="#" data-type="facility" data-id="${f.id}">${f.name}</a></li>`)
                                         .join('')}</ul></div>`;
                                 }
 
                                 if (personsInDepartment && personsInDepartment.length > 0) {
-                                    detailsHtml += `<div class="department-column"><h3>Mitarbeitende</h3><ul>${personsInDepartment
+                                    detailsHtml += `<div class="department-column employees-column"><h3>Mitarbeitende</h3><ul>${personsInDepartment
                                         .map(p => `<li><a href="#" data-type="person" data-id="${p.id}">${p.name}</a></li>`)
                                         .join('')}</ul></div>`;
                                 }

--- a/styles.css
+++ b/styles.css
@@ -235,8 +235,15 @@ ul.languages {
     .department-columns {
         flex-direction: row;
     }
-    .department-column {
-        flex: 1;
+    .department-column.facilities-column {
+        flex: 0 0 40%;
+    }
+    .department-column.employees-column {
+        flex: 0 0 60%;
+    }
+    .department-column.employees-column ul {
+        column-count: 2;
+        column-gap: 20px;
     }
 }
 


### PR DESCRIPTION
## Summary
- Split department modal columns 40/60 between facilities and employees
- Render employee list in two columns for better overview

## Testing
- `node --check script.js`


------
https://chatgpt.com/codex/tasks/task_e_68b31c88beb883278e447eaae35ea2c2