### PR TITLE
Ensure fresh departments CSV is always loaded

### DIFF
--- a/visualize.html
+++ b/visualize.html
@@ -85,7 +85,9 @@ if(searchInput){
 // Automatisch vorhandene departments.csv laden
 async function loadDefaultCSV(){
   try{
-    const resp = await fetch('departments.csv');
+    // Cache-Busting: immer aktuelle CSV laden
+    const url = `departments.csv?cachebust=${Date.now()}`;
+    const resp = await fetch(url, {cache: 'no-store'});
     if(resp.ok){
       const text = await resp.text();
       data = parseCSV(text);


### PR DESCRIPTION
## Summary
- Prevent caching when fetching departments.csv in `visualize.html`

## Testing
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b4179e7ce88327917413c632928966