### PR TITLE
Avoid caching when loading ifak.json

### DIFF
--- a/script.js
+++ b/script.js
@@ -13,7 +13,7 @@ const word2List = [
 async function loadData() {
     try {
         console.log("Attempting to load data...");
-        const response = await fetch('ifak.json');
+        const response = await fetch(`ifak.json?${Date.now()}`, { cache: 'no-store' });
         if (!response.ok) {
             throw new Error(`HTTP error! status: ${response.status}`);
         }


### PR DESCRIPTION
## Summary
- Bypass browser cache by fetching `ifak.json` with a timestamp and `no-store` directive

## Testing
- `node --check script.js`


------
https://chatgpt.com/codex/tasks/task_e_68b4193dd2348327a81399d5138ece24