### PR TITLE
Show folder counts per SharePoint

### DIFF
--- a/visualize.html
+++ b/visualize.html
@@ -64,6 +64,11 @@ function render(rows, q=''){
       subs.forEach(s=>tree[root].add(s));
     });
 
+    // Anzahl der Ordner erster und zweiter Ebene ermitteln
+    const rootCount = Object.keys(tree).length;
+    const subCount = Object.values(tree).reduce((sum, set)=> sum + set.size, 0);
+    title.textContent = `${r.Title || '(ohne Titel)'} (${rootCount}/${subCount})`;
+
     Object.entries(tree).forEach(([root, subs])=>{
       const li = document.createElement('li');
       li.textContent = root;


### PR DESCRIPTION
## Summary
- count first- and second-level folders per SharePoint
- display counts next to SharePoint title

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b8926f14708327a5fde63ffd95b702